### PR TITLE
Add Cypress E2E tests for Work.co homepage

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -3,7 +3,7 @@ const { defineConfig } = require("cypress");
 module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
-      // implement node event listeners here
+     
     },
   },
 });

--- a/cypress/e2e/homepage.cy.js
+++ b/cypress/e2e/homepage.cy.js
@@ -1,0 +1,29 @@
+describe('Work.co homepage', () => {
+    it('Test case 1', () => {
+        cy.visit('https://work.co/')
+        cy.title().should('eq', 'Work & Co | Digital Product Agency')
+        cy.contains('We solve complex problems through design & technology')
+    })
+
+    it('Test case 2', () => {
+        cy.visit('https://work.co/')
+        cy.get('[data-test-id="global-menu-btn"]').click()
+        cy.url().should('eq', 'https://work.co/grid') 
+    })
+
+    it('Test case 3', () => {
+        cy.visit('https://work.co/')
+        cy.get('[data-test-id="global-menu-btn"]').click()
+        cy.get('[data-test-id="grid-select-clients-link"]').click()
+        cy.url().should('eq', 'https://work.co/clients/')
+      })
+
+      it('Test case 4', () => {
+        cy.visit('https://work.co/')
+        cy.get('[data-test-id="global-menu-btn"]').click()
+        cy.get('[data-test-id="grid-expertise-capabilities-link"]').click()
+        cy.url().should('eq', 'https://work.co/company/')
+      })
+    
+
+})


### PR DESCRIPTION
# Description
This PR adds end-to-end (E2E) tests for the Work.co homepage using Cypress. The tests cover the following scenarios:

## Test Case 1:
Open URL https://work.co/
Check the page title is "Work & Co | Digital Product Agency"
Check the headline "We solve complex problems through design & technology" is visible

## Test Case 2:
Open URL https://work.co/
Click on the W&C logo (red)
Check the page URL is https://work.co/grid

## Test Case 3:
Open URL https://work.co/
Click on the W&C logo (red)
Click on the "Select Clients" link
Check the page URL is https://work.co/clients

## Test Case 4:
Open URL https://work.co/
Click on the W&C logo (red)
Click on the "Expertise & Capabilities" grid element
Check the page URL is https://work.co/company

## Changes:
Added homepage.cy.js in the cypress/e2e directory with the above test cases.
Ensured all selectors use data-test-id attributes for reliability.
Removed unnecessary comments and code to keep the configuration clean.

## How to run the tests:
Ensure you have Cypress installed.
Open Cypress: npx cypress open
Run the homepage.cy.js spec from the Cypress GUI.